### PR TITLE
change container ENV names

### DIFF
--- a/artifactory-deployment.yaml
+++ b/artifactory-deployment.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: artifactory-oss
-        image: docker.bintray.io/jfrog/artifactory-oss:latest
+        image: docker.bintray.io/jfrog/artifactory-oss:5.8.3
         ports:
         - name: http-port
           containerPort: 8081

--- a/pfc-configmap.yaml
+++ b/pfc-configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 data:
   DB_ENDPOINT: mysql://mysql-service:3306/pfc
-  DB_PASS: p@ssW0rd!
-  DB_USER: pfc
+  MYSQL_PWD: p@ssW0rd!
+  USER: pfc
 kind: ConfigMap
 metadata:
   labels:

--- a/pfc-frontend.yaml
+++ b/pfc-frontend.yaml
@@ -24,15 +24,15 @@ spec:
           hostPort: 8000
           protocol: TCP
         env:
-        - name: DB_USER
+        - name: USER
           valueFrom:
             configMapKeyRef:
-              key: DB_USER
+              key: USER
               name: pfc-frontend-config
-        - name: DB_PASS
+        - name: MYSQL_PWD
           valueFrom:
             configMapKeyRef:
-              key: DB_PASS
+              key: MYSQL_PWD
               name: pfc-frontend-config
         - name: DB_ENDPOINT
           valueFrom:


### PR DESCRIPTION
The PFC container uses different environment variables than PFA, so these had to be changed so that we don't see these messages:

```
java.sql.SQLInvalidAuthorizationSpecException: Could not connect: Access denied for user 'root'@'10.0.0.8' (using password: NO)
```

You can see the variables documented here: https://puppet.com/docs/pipelines-for-containers/enterprise/install-setup.html#install-pipelines-for-containers

There also seems to be an issue with artifactory, I tried pinning the version in order to fix this but the app still doesn't initialize all the way.